### PR TITLE
Build/ci cache

### DIFF
--- a/.github/actions/install_python_dependencies/action.yml
+++ b/.github/actions/install_python_dependencies/action.yml
@@ -1,6 +1,7 @@
 name: Install Python dependencies
 
 runs:
+  using: "composite"
   steps:
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/install_python_dependencies/action.yml
+++ b/.github/actions/install_python_dependencies/action.yml
@@ -1,0 +1,20 @@
+name: Install Python dependencies
+
+runs:
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: pip install -r requirements.txt
+      shell: bash

--- a/.github/workflows/daily_stock_news.yml
+++ b/.github/workflows/daily_stock_news.yml
@@ -9,7 +9,7 @@ jobs:
   scrape-and-notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Python dependencies
         uses: ./.github/actions/install_python_dependencies

--- a/.github/workflows/daily_stock_news.yml
+++ b/.github/workflows/daily_stock_news.yml
@@ -11,15 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+      - name: Install Python dependencies
+        uses: ./.github/actions/install_python_dependencies
 
       - name: Run scraper and send notifications
         env:

--- a/.github/workflows/etf_analysis.yml
+++ b/.github/workflows/etf_analysis.yml
@@ -14,15 +14,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+      - name: Install Python dependencies
+        uses: ./.github/actions/install_python_dependencies
 
       - name: Run analysis
         env:

--- a/.github/workflows/etf_analysis.yml
+++ b/.github/workflows/etf_analysis.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Python dependencies
         uses: ./.github/actions/install_python_dependencies

--- a/.github/workflows/stock_price_notification.yml
+++ b/.github/workflows/stock_price_notification.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Python dependencies
         uses: ./.github/actions/install_python_dependencies

--- a/.github/workflows/stock_price_notification.yml
+++ b/.github/workflows/stock_price_notification.yml
@@ -14,15 +14,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+      - name: Install Python dependencies
+        uses: ./.github/actions/install_python_dependencies
 
       - name: Run stock price notification script
         env:


### PR DESCRIPTION
1. Caching Python dependencies to reduce execution time.
2. Changing actions version to avoid deprecation.